### PR TITLE
Add in the ability to bring your own tokenizer

### DIFF
--- a/src/vllm_haystack/__init__.py
+++ b/src/vllm_haystack/__init__.py
@@ -36,15 +36,15 @@ class vLLMInvocationLayer(PromptModelInvocationLayer):
         api_base: str,
         max_length: Optional[int] = 100,
         model_name_or_path: Optional[str] = None,
-        tokenizer: Optional[str] = None,
-        hf_token:Optional[str] = None,
+        tokenizer: Optional[Union[str, object]] = None,
+        hf_token: Optional[str] = None,
         maximum_context_length: Optional[int] = None,
         **kwargs,
     ):
         """
         Creates an instance of vLLMInvocationLayer for an hosted vLLM server.
 
-        :param api_base: The base url, used to cummunicate with your vLLM server. E.g. `https://[MY Server]/v1`.
+        :param api_base: The base url, used to communicate with your vLLM server. E.g. `https://[MY Server]/v1`.
         :param model_name_or_path: The name or path of the underlying model.
         :param max_length: The maximum number of tokens the output text can have.
         :param tokenizer: Optional tokenizer to load from the hub.
@@ -101,7 +101,12 @@ class vLLMInvocationLayer(PromptModelInvocationLayer):
             if key in kwargs
         }
 
-        self.tokenizer = Tokenizer.from_pretrained(tokenizer or model_name_or_path,auth_token=hf_token)
+        if isinstance(tokenizer, str) or tokenizer is None:
+            self.tokenizer = Tokenizer.from_pretrained(tokenizer or model_name_or_path,auth_token=hf_token)
+        else:
+            if not hasattr(tokenizer, "encode"):
+                raise AttributeError(f"tokenizer `{type(tokenizer)}` does not provide an `encode` method")
+            self.tokenizer = tokenizer
 
         #Infer the context length of the model
         if maximum_context_length:
@@ -209,7 +214,12 @@ class vLLMInvocationLayer(PromptModelInvocationLayer):
 
         :param prompt: Prompt text to be sent to the generative model.
         """
-        encoded_prompt = list(self.tokenizer.encode(cast(str, prompt)).ids)
+        encoding = self.tokenizer.encode(cast(str, prompt))
+        if not isinstance(encoding, list):
+            encoded_prompt = list(encoding.ids)
+        else:
+            # the provided tokenizer natively returns the ids from the encode call, such as a Transformers tokenizer
+            encoded_prompt = list(encoding)
         n_prompt_tokens = len(encoded_prompt)
         n_answer_tokens = self.max_length
         if (n_prompt_tokens + n_answer_tokens) <= self.max_tokens_limit:


### PR DESCRIPTION
Per your information in the Haystack Discord, using the adapter with an `OpenAI` compatible endpoint, and saw it could be useful to bring your own tokenizer if necessary.

The code works as is, but a GPTQ model I've been testing uses the `transformers` library's `AutoTokenizer` to create a tokenizer specific to the model (in this case, the auto-tokenizer is creating an instance of `transformers.models.llama.tokenization_llama_fast.LlamaTokenizerFast`). In this particular case, the `encode` function returns the list of `ids` as the result of the call, instead of passing back an object with `ids` as an attribute.

Using `Tokenizer.from_pretrained` on this model _does_ work, so I'm not married to the PR, but still thought it would be useful. The only bit I'm not particularly thrilled with is `line 218`, where I'm making a naive assumption that those are the only two scenarios - a list returned natively by the encoder, or an object with the `ids` attribute.